### PR TITLE
Load Google Maps resources over https instead of http

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ if ($javascript == "") {
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
 	<link rel=StyleSheet href="style.css" type="text/css" media=screen>
     <title>NagMap <?php echo $nagmap_version ?></title>
-    <script src="http://maps.google.com/maps/api/js?sensor=false" type="text/javascript"></script>
+    <script src="https://maps.google.com/maps/api/js?sensor=false" type="text/javascript"></script>
     <script type="text/javascript">
 
     //static code from index.pnp
@@ -35,27 +35,27 @@ if ($javascript == "") {
 
       //defining marker images
       var red_blank = new google.maps.MarkerImage(
-        'http://www.google.com/mapfiles/marker.png',
+        'https://www.google.com/mapfiles/marker.png',
         new google.maps.Size(20,34),
         new google.maps.Point(10,34));
 
       var blue_blank = new google.maps.MarkerImage(
-        'http://www.google.com/mapfiles/marker_white.png',
+        'https://www.google.com/mapfiles/marker_white.png',
         new google.maps.Size(20,34),
         new google.maps.Point(10,34));
 
       var green_blank = new google.maps.MarkerImage(
-        'http://www.google.com/mapfiles/marker_green.png',
+        'https://www.google.com/mapfiles/marker_green.png',
         new google.maps.Size(20,34),
         new google.maps.Point(10,34));
 
       var yellow_blank = new google.maps.MarkerImage(
-        'http://www.google.com/mapfiles/marker_yellow.png',
+        'https://www.google.com/mapfiles/marker_yellow.png',
         new google.maps.Size(20,34),
         new google.maps.Point(10,34));
 
       var grey_blank = new google.maps.MarkerImage(
-        'http://www.google.com/mapfiles/marker_grey.png',
+        'https://www.google.com/mapfiles/marker_grey.png',
         new google.maps.Size(20,34),
         new google.maps.Point(10,34));
 

--- a/marker.php
+++ b/marker.php
@@ -109,7 +109,7 @@ foreach ($data as $h) {
     if ($h['status'] == 0) {
       $javascript .= ('window.'.$h["host_name"]."_mark = new google.maps.Marker({".
         "\n  position: ".$h["host_name"]."_pos,".
-        "\n  icon: 'http://www.google.com/mapfiles/marker_green.png',".
+        "\n  icon: 'https://www.google.com/mapfiles/marker_green.png',".
         "\n  map: map,".
         "\n  zIndex: 2,".
         "\n  title: \"".$h["nagios_host_name"]."\"".
@@ -120,7 +120,7 @@ foreach ($data as $h) {
     } elseif ($h['status'] == 1) {
       $javascript .= ('window.'.$h["host_name"]."_mark = new google.maps.Marker({".
         "\n  position: ".$h["host_name"]."_pos,".
-        "\n  icon: 'http://www.google.com/mapfiles/marker_yellow.png',".
+        "\n  icon: 'https://www.google.com/mapfiles/marker_yellow.png',".
         "\n  map: map,".
         "\n  zIndex: 3,".
         "\n  title: \"".$h["nagios_host_name"]."\"".
@@ -131,7 +131,7 @@ foreach ($data as $h) {
     } elseif ($h['status'] == 2) {
       $javascript .= ('window.'.$h["host_name"]."_mark = new google.maps.Marker({".
         "\n  position: ".$h["host_name"]."_pos,".
-        "\n  icon: 'http://www.google.com/mapfiles/marker.png',".
+        "\n  icon: 'https://www.google.com/mapfiles/marker.png',".
         "\n  map: map,".
         "\n  zIndex: 4,".
         "\n  title: \"".$h["nagios_host_name"]."\"".
@@ -142,7 +142,7 @@ foreach ($data as $h) {
     } elseif ($h['status'] == 3) {
       $javascript .= ('window.'.$h["host_name"]."_mark = new google.maps.Marker({".
         "\n  position: ".$h["host_name"]."_pos,".
-        "\n  icon: 'http://www.google.com/mapfiles/marker_grey.png',".
+        "\n  icon: 'https://www.google.com/mapfiles/marker_grey.png',".
         "\n  map: map,".
         "\n  zIndex: 2,".
         "\n  title: \"".$h["nagios_host_name"]."\"".
@@ -153,7 +153,7 @@ foreach ($data as $h) {
     // if host is in any other (unknown to nagmap) state
       $javascript .= ('window.'.$h["host_name"]."_mark = new google.maps.Marker({".
         "\n  position: ".$h["host_name"]."_pos,".
-        "\n  icon: 'http://www.google.com/mapfiles/marker_grey.png',".
+        "\n  icon: 'https://www.google.com/mapfiles/marker_grey.png',".
         "\n  map: map,".
         "\n  zIndex: 6,".
         "\n  title: \"".$h["nagios_host_name"]."\"".


### PR DESCRIPTION
If the nagmap installation is served over a secure connection, then all external resources pulled in should also be served over a secure connection, otherwise this will trigger a mixed content warning in the browser and/or will prevent the browser from loading the external resources at all.

It's safe (and, in fact, nowadays highly recommended) to load the Google Maps resources over https even when not serving nagmap over https, so we should always use the https:// scheme instead of protocol-relative URLs.
