### PR TITLE
Parameterize Nagios CGI script location

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -5,6 +5,12 @@
 $nagios_cfg_file = "/usr/local/nagios/etc/nagios.cfg";
 $nagios_status_dat_file = "/usr/local/nagios/var/status.dat";
 
+// Base URL fragment for the Nagios CGI scripts as seen from the webserver serving this
+// nagmap installation. Usually this will be "/nagios/cgi-bin" or "/cgi-bin/nagios".
+// Consult the webserver configuration for details (e.g., for Apache look for ScriptAlias lines.)
+// No need to include the trailing slash.
+$nagios_cgi_url_base = "/nagios/cgi-bin";
+
 // hostgroup filter - only show hosts from this hotgroup
 // leave empty for not filtering
 $nagmap_filter_hostgroup  = '';

--- a/marker.php
+++ b/marker.php
@@ -161,6 +161,9 @@ foreach ($data as $h) {
     };
     //generate google maps info bubble
     if (!isset($h["parents"])) { $h["parents"] = Array(); }; 
+    if (!isset($nagios_cgi_url_base)) {
+        $nagios_cgi_url_base = '/nagios/cgi-bin'; // ensures we don't break old installations whose config.php doesn't contain this variable
+    }
     $info = '<div class=\"bubble\">'.$h["nagios_host_name"]."<br><table>"
          .'<tr><td>alias</td><td>'.$h["alias"].'</td></tr>'
          .'<tr><td>hostgroups</td><td>'.join('<br>', $h["hostgroups"]).'</td></tr>'
@@ -168,8 +171,8 @@ foreach ($data as $h) {
          .'<tr><td>other</td><td>'.join("<br>",$h['user']).'</td></tr>'
          .'<tr><td>parents</td><td>'.join('<br>', $h["parents"]).'</td></tr>'
          .'<tr><td>status</td><td>('.$h['status'].') '.$h['status_human'].'</td></tr>'
-         .'<tr><td colspan=2><a href=\"/nagios/cgi-bin/statusmap.cgi\?host='.$h["nagios_host_name"].'\">Nagios map page</a></td></tr>'
-         .'<tr><td colspan=2><a href=\"/nagios/cgi-bin/extinfo.cgi\?type=1\&host='.$h["nagios_host_name"].'\">Nagios host page</a></td></tr>'
+         .'<tr><td colspan=2><a href=\"'.$nagios_cgi_url_base.'/statusmap.cgi\?host='.$h["nagios_host_name"].'\">Nagios map page</a></td></tr>'
+         .'<tr><td colspan=2><a href=\"'.$nagios_cgi_url_base.'/extinfo.cgi\?type=1\&host='.$h["nagios_host_name"].'\">Nagios host page</a></td></tr>'
          .'</table>';
 
     if ($nagmap_bubble_extra) {


### PR DESCRIPTION
The current scripts hardcode the Nagios / Icinga CGI location. This commit enables the user to override that location via config.php. Backwards compatibility is ensured by providing a default fallback to the old formerly hardcoded value (this is necessary for older installs which won't have the new setting in their config.php.)

In other words, for both new and existing users nothing will change unless they want to, but they now have the option without having to alter marker.php deviating from upstream.

Tested in both possible scenarios, clean install and migration from an older version, without encountering any issues.
